### PR TITLE
Fix whop sdk retrievecurrentuser type error

### DIFF
--- a/lib/server-auth.ts
+++ b/lib/server-auth.ts
@@ -6,7 +6,7 @@ import { AppUser } from './types';
 export async function authenticateUser(accessToken: string): Promise<AppUser> {
 	try {
 		// Validate the access token and get user data from Whop
-		const userData = await whopSdk.withUser(accessToken).users.retrieveCurrentUser();
+		const userData = await whopSdk.withUser(accessToken).users.getCurrentUser();
 		
 		if (!userData || !userData.id) {
 			throw new Error('Invalid user data received from Whop');


### PR DESCRIPTION
Fixes a TypeScript compilation error by changing `retrieveCurrentUser` to `getCurrentUser` in the Whop SDK call.

---
<a href="https://cursor.com/background-agent?bcId=bc-6041dad0-119e-42d6-9d4d-2970fa4255b4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6041dad0-119e-42d6-9d4d-2970fa4255b4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

